### PR TITLE
Update README with extension info

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ I'm a senior C++ software developer
 
 ### Projects
 
-I'm developing QmlSandbox extension for Visual Studio Code
+I'm developing [QmlSandbox extension](https://marketplace.visualstudio.com/items?itemName=SavenkovIgor.QmlSandboxExtension) for Visual Studio Code
 [![Installs](https://vsmarketplacebadges.dev/installs/SavenkovIgor.QmlSandboxExtension.svg)](https://marketplace.visualstudio.com/items?itemName=SavenkovIgor.QmlSandboxExtension)

--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ I'm a senior C++ software developer
 [![GitHub Actions](https://img.shields.io/badge/GitHub%20Actions-2088FF?style=flat-square&logo=github-actions&logoColor=white)](https://github.com/features/actions)
 [![GitLab CI/CD](https://img.shields.io/badge/GitLab%20CI%2FCD-FC6D26?style=flat-square&logo=gitlab&logoColor=white)](https://docs.gitlab.com/ee/ci/)
 
+
+### Projects
+
+I'm developing QmlSandbox extension for Visual Studio Code
+[![Installs](https://vsmarketplacebadges.dev/installs/SavenkovIgor.QmlSandboxExtension.svg)](https://marketplace.visualstudio.com/items?itemName=SavenkovIgor.QmlSandboxExtension)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ I'm a senior C++ software developer
 [![GitLab CI/CD](https://img.shields.io/badge/GitLab%20CI%2FCD-FC6D26?style=flat-square&logo=gitlab&logoColor=white)](https://docs.gitlab.com/ee/ci/)
 
 
-### Projects
+### Featured personal projects
 
-I'm developing [QmlSandbox extension](https://marketplace.visualstudio.com/items?itemName=SavenkovIgor.QmlSandboxExtension) for Visual Studio Code
+- [TermGraph](https://termgraph.app) - knowledge mapping and graphs
+- [QmlSandbox](https://marketplace.visualstudio.com/items?itemName=SavenkovIgor.QmlSandboxExtension) live QML viewer extension for Visual Studio Code
 [![Installs](https://vsmarketplacebadges.dev/installs/SavenkovIgor.QmlSandboxExtension.svg)](https://marketplace.visualstudio.com/items?itemName=SavenkovIgor.QmlSandboxExtension)


### PR DESCRIPTION
## Summary
- add project section for QmlSandbox extension

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684eff28bbd48323bc2ad7571afb89f7